### PR TITLE
Displaying errors for extra variables

### DIFF
--- a/src/webview/plugins/demo.ts
+++ b/src/webview/plugins/demo.ts
@@ -1839,12 +1839,9 @@ function addExpressionComponent(spec, api) {
 
   <div id="texPreview" >
   ${() => {
-    // TODO ask about comparing against constants defined in `fpcorejs`
     try {
       if (text() === '') { return '' }
-      console.log("Watch")
-      console.log(fpcorejs.symbols())
-      console.log("Watch")
+      const symbols = fpcorejs.symbols()
       var errorOutput: String[] = []
       // get error messages concerning math syntax 
       // only return only one error
@@ -1863,9 +1860,12 @@ function addExpressionComponent(spec, api) {
       let newVars = fpcorejs.getVarnamesMathJS(text())
       let errorVars: String[] = []
       for (var newVar of newVars) {
+        if (symbols.includes(newVar)) {
+          continue
+        }
         if (!variableNames.includes(newVar)) {
           // Should trigger after there are no Math Syntax errors
-            errorVars.push(newVar)
+          errorVars.push(newVar)
         }
       }
       if (errorVars.length > 0) {

--- a/src/webview/plugins/demo.ts
+++ b/src/webview/plugins/demo.ts
@@ -1832,7 +1832,6 @@ function addExpressionComponent(spec, api) {
       // get error messages concerning math syntax 
       // only return only one error
       let errorArray = fpcorejs.parseErrors(text())
-
       for (var errorVal of errorArray) {
         errorOutput.push(errorVal)
       }
@@ -1845,11 +1844,15 @@ function addExpressionComponent(spec, api) {
       }
       // grab variables from input
       let newVars = fpcorejs.getVarnamesMathJS(text())
+      let errorVars: String[] = []
       for (var newVar of newVars) {
         if (!variableNames.includes(newVar)) {
           // Should trigger after there are no Math Syntax errors
-          errorOutput.push("Error: The current expression contains more variables than the initial expression.")
+            errorVars.push(newVar)
         }
+      }
+      if (errorVars.length > 0) {
+        errorOutput.push(`Error: The current expression contains more variables than the initial expression. Additional variables: ${errorVars}.`)
       }
       let output = (window as any).katex.renderToString(math2Tex(text().split('\n').join('')), {
         throwOnError: false

--- a/src/webview/plugins/demo.ts
+++ b/src/webview/plugins/demo.ts
@@ -1812,6 +1812,18 @@ function addExpressionComponent(spec, api) {
   
   async function addExpression() {
     const ranges = JSON.parse(rangeText.value)
+    let variableNames: string[] = []
+    // grab variable from ranges
+    let newVars = fpcorejs.getVarnamesMathJS(text())
+
+    for (var val of spec.ranges) {
+      variableNames.push(val[0])
+    }
+    for (var newVar of newVars) {
+      if (!variableNames.includes(newVar)) { 
+        console.log(`Extra Variable ${newVar}`) 
+      }
+    }
     await ensureSpecWithThoseRangesExists(ranges)
     makeExpression(specWithRanges(ranges), text().startsWith('[[') ? text().slice(2) : fpcorejs.mathjsToFPCore(text().split('\n').join(''), spec.fpcore), text().startsWith('[[') ? text().slice(2) : text().split('\n').join(''))()  // HACK to support FPCore submission
   }

--- a/src/webview/plugins/demo.ts
+++ b/src/webview/plugins/demo.ts
@@ -1810,6 +1810,10 @@ function addExpressionComponent(spec, api) {
     await addSpec({ ...spec, ranges })
   }
   
+  // Set to true if there are extra not previously defined variables added
+  // after the initial expression
+  const [userExtraVarsError, setUserExtraVarsError] = createSignal(false)
+  
   async function addExpression() {
     const ranges = JSON.parse(rangeText.value)
     let variableNames: string[] = []
@@ -1821,9 +1825,11 @@ function addExpressionComponent(spec, api) {
     }
     for (var newVar of newVars) {
       if (!variableNames.includes(newVar)) { 
+        setUserExtraVarsError(true)
         console.log(`Extra Variable ${newVar}`) 
       }
     }
+    console.log(`error state: ${userExtraVarsError()}`) 
     await ensureSpecWithThoseRangesExists(ranges)
     makeExpression(specWithRanges(ranges), text().startsWith('[[') ? text().slice(2) : fpcorejs.mathjsToFPCore(text().split('\n').join(''), spec.fpcore), text().startsWith('[[') ? text().slice(2) : text().split('\n').join(''))()  // HACK to support FPCore submission
   }
@@ -1857,6 +1863,10 @@ function addExpressionComponent(spec, api) {
   ${() => {
     try {
       if (text() === '') { return '' }
+      if (userExtraVarsError()) {
+        console.log("error triggered")
+        return html`<span class="preview-stuff" innerHTML=${"Error, Zane was here"}></span>`
+      }
       return html`<span class="preview-stuff" innerHTML=${(window as any).katex.renderToString(math2Tex(text().split('\n').join('')), {
         throwOnError: false
       })}></span>`

--- a/src/webview/plugins/demo.ts
+++ b/src/webview/plugins/demo.ts
@@ -52,6 +52,20 @@ function getColorCode(seed) {
 }
 
 const fpcorejs = (() => {
+  function symbols() {
+    var symbols: String[] = []
+    for (const [key,_] of Object.entries(CONSTANTS)) {
+      symbols.push(`${key}`)
+    }
+    for (const [key,_] of Object.entries(FUNCTIONS)) {
+      symbols.push(`${key}`)
+    }
+    for (const [key,_] of Object.entries(SECRETFUNCTIONS)) {
+      symbols.push(`${key}`)
+    }
+    // {CONSTANTS, FUNCTIONS, SECRETFUNCTIONS}
+    return symbols
+  }
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const CONSTANTS = { "PI": "real", "E": "real", "TRUE": "bool", "FALSE": "bool" }
 
@@ -334,6 +348,7 @@ const fpcorejs = (() => {
 
   return {
     //dumpFPCore: dump_fpcore,  // Currently has no error handling!
+    symbols: symbols,
     rangeErrors: get_input_range_errors,
     FPCorePrecondition: get_precondition_from_input_ranges,
     getVarnamesMathJS: get_varnames_mathjs,
@@ -1827,7 +1842,9 @@ function addExpressionComponent(spec, api) {
     // TODO ask about comparing against constants defined in `fpcorejs`
     try {
       if (text() === '') { return '' }
-
+      console.log("Watch")
+      console.log(fpcorejs.symbols())
+      console.log("Watch")
       var errorOutput: String[] = []
       // get error messages concerning math syntax 
       // only return only one error

--- a/src/webview/plugins/demo.ts
+++ b/src/webview/plugins/demo.ts
@@ -1848,23 +1848,32 @@ function addExpressionComponent(spec, api) {
       let output = (window as any).katex.renderToString(math2Tex(text().split('\n').join('')), {
         throwOnError: false
       })
-      let variableNames: string[] = []
-      // grab variable from ranges
-      let newVars = fpcorejs.getVarnamesMathJS(text())
-      // console.log(`Number of vars ${newVars.length}`)
-      for (var val of spec.ranges) {
-        variableNames.push(val[0])
-      }
-      for (var newVar of newVars) {
-        if (!variableNames.includes(newVar)) { 
-          // Should trigger after there are no Math Syntax errors
-          output = "Error: Extra Variable"
-          console.log(`Extra Variable ${newVar}`) 
-          break
+      // get error messages concerning math syntax 
+      let errorArray = fpcorejs.parseErrors(text())
+      // If there are errors in the syntax, we want to display those, instead
+      // of displaying errors about extra variables.
+      if (errorArray.length > 0) {
+        output = errorArray
+      } else {
+        // We are at the case where there are no syntax errors, so if there are
+        // more variables than the original expression had, we display that as
+        // an error to the user.
+        let variableNames: string[] = []
+        for (var val of spec.ranges) {
+          variableNames.push(val[0])
+        }
+        // grab variables from input
+        let newVars = fpcorejs.getVarnamesMathJS(text())
+        for (var newVar of newVars) {
+          if (!variableNames.includes(newVar)) {
+            // Should trigger after there are no Math Syntax errors
+            output = "Error: The current expression contains more variables than the initial expression."
+            break
+          }
         }
       }
       return html`<span class="preview-stuff" innerHTML=${output}></span>`
-    } catch (err :any) {
+    } catch (err: any) {
       return err.toString()
     }
   }}


### PR DESCRIPTION
Because there were several instances of the same Debounce function, we factored out 3 of the instances into one instance and called it where the code was copied.

Most of the changes are related to finding and displaying errors. After the user has submitted an initial expression, in addExpressionComponent, in the texPreview box, we now do logic for checking if a new variable (not in the original expression) is found in subsequent expressions. If it is, we display an error.

Additionally in texPreview, we also display errors related to syntax, propagated from fpcorejs.parseErrors. Currently, this will only display one of these errors at a time, even if there are multiple in an equation. However, it can display one of our "multi-variable" errors and one of the errors found by the parseErrors. 