### PR TITLE
Validate expressions without throwing error, ban FPCore function names as variables.

### DIFF
--- a/src/ExpressionTable.tsx
+++ b/src/ExpressionTable.tsx
@@ -186,6 +186,7 @@ function ExpressionTable() {
             <div className="add-expression-tex" dangerouslySetInnerHTML={{
                 __html: (() => {
                   try {      
+                    validateExpression(addExpression);
                     return addExpression.trim() === '' ? '' : KaTeX.renderToString(math11.parse(addExpression).toTex(), { throwOnError: false })
                   } catch (e) {
                     //throw e;

--- a/src/ExpressionTable.tsx
+++ b/src/ExpressionTable.tsx
@@ -126,6 +126,18 @@ function ExpressionTable() {
         variableListString;
       return [errorMessage];
     }
+
+    const functionNames = Object.keys(fpcore.SECRETFUNCTIONS).concat(Object.keys(fpcore.FUNCTIONS));
+    const expressionVariables = fpcore.getVarnamesMathJS(expression);
+    const functionNamedVariables = expressionVariables.filter((symbol) => functionNames.includes(symbol));
+    if (functionNamedVariables.length !== 0) {
+      const functionVariableString = functionNamedVariables.join(", ");
+      const errorMessage =
+        "The added expression is not valid. The expression you tried to add has the following variables that have the same name as FPCore functions: " +
+        functionVariableString;    
+      return [errorMessage];
+    }
+
     return []
   }
 

--- a/src/fpcore.ts
+++ b/src/fpcore.ts
@@ -347,5 +347,7 @@ export {
   parseErrors,
   FPCoreBody,
   FPCoreGetBody,  // HACK just the fpcore version of the above, gets just the body
-  mathjsToFPCore
+  mathjsToFPCore,
+  SECRETFUNCTIONS,
+  FUNCTIONS
 }


### PR DESCRIPTION
Validates expressions before generating TeX. Shows error message before user attempts to add to expression table.

Adds validation to ban FPCore functions in new expressions. Shows the following error message:

"The added expression is not valid. The expression you tried to add has the following variables that have the same name as FPCore functions: "