### PR TITLE
Prune extra variables from input ranges before submitting spec expression

### DIFF
--- a/src/SpecComponent.tsx
+++ b/src/SpecComponent.tsx
@@ -62,11 +62,14 @@ function SpecComponent({ showOverlay, setShowOverlay }: { showOverlay: boolean, 
   const handleSubmitClick = () => {
     const specId = value.id + 1;
     const inputRangeId = utils.nextId(inputRangesTable)
-
+    const variables = getVariables(spec)
     // Reset the expressions list if we are truly switching specs
     if (spec.expression !== value.expression) { setArchivedExpressions(expressions.map(e => e.id)) }
 
-    const inputRanges = new HerbieTypes.InputRanges(mySpecRanges, specId, inputRangeId)
+    const inputRanges = new HerbieTypes.InputRanges(
+      mySpecRanges.filter((range) => variables.includes(range.variable)),
+      specId, 
+      inputRangeId)
     console.debug('Adding to inputRangesTable: ', inputRanges)
     setInputRangesTable([...inputRangesTable, inputRanges])
     const mySpec = new Spec(spec.expression, specId);


### PR DESCRIPTION
Previously reported a bug where a user could:

-write x + y + z in spec editor
-change expression to x + y
-submit expression
-get a bug because input ranges included the specified input range for z

This PR filters out extraneous input ranges before adding the input ranges to the inputRangesTable.  