### PR TITLE
Fix behavior with table expressions that have fewer variables than spec.

### DIFF
--- a/src/ErrorPlot.tsx
+++ b/src/ErrorPlot.tsx
@@ -195,7 +195,7 @@ function ErrorPlot() {
     // throw new Error(`Could not find expression with id ${selectedExprId}`)
   }
   // get the variables from the expression
-  const varnames = fpcorejs.getVarnamesMathJS(selectedExpr.text)
+  const varnames = fpcorejs.getVarnamesMathJS(spec.expression)
   // we will iterate over indices
   
   if (!sample) {
@@ -297,7 +297,7 @@ function ErrorPlot() {
     <button className="resample" onClick={ resample }>Resample</button>
     {vars.map((v, i) => {
       const range = inputRanges.find(r => r.variable === v)
-      if (!range) {
+      if (!range ) {
         return <div>Could not find range for variable {v}, which should be in {JSON.stringify(inputRanges)}</div>
       }
       return <div key={i}>

--- a/src/HerbieUI.tsx
+++ b/src/HerbieUI.tsx
@@ -151,10 +151,8 @@ function HerbieUIInner() {
 
         try {
           // HACK to make sampling work on Herbie side
-          const vars = fpcorejs.getVarnamesMathJS(expression.text)
           const specVars = fpcorejs.getVarnamesMathJS(spec.expression)
-          const modSample = new Sample(sample.points.map(([x, y], _) => [x.filter((xi, i) => vars.includes(specVars[i])), y]), sample.specId, sample.inputRangesId, sample.id)
-          const analysis = await herbiejs.analyzeExpression(fpcorejs.mathjsToFPCore(expression.text), modSample, serverUrl)
+          const analysis = await herbiejs.analyzeExpression(fpcorejs.mathjsToFPCore(expression.text,spec.expression, specVars), sample, serverUrl)
           console.log('Analysis was:', analysis)
           // analysis now looks like [[[x1, y1], e1], ...]. We want to average the e's
 


### PR DESCRIPTION
Treats table expressions as functions of all the spec's variables when sending to Herbie's `analyze` endpoint. Plots error with respect to each spec variable.