### PR TITLE
Bug Fixed

### DIFF
--- a/src/herbie/ErrorPlot.tsx
+++ b/src/herbie/ErrorPlot.tsx
@@ -200,9 +200,7 @@ function ErrorPlot() {
   const expressions = allExpressions.filter(e => !archivedExpressions.includes(e.id))
 
   // console.log('selectedExprId', selectedExprId)
-  if (expressions.length > 0 && selectedExprId === -1) {
-    setSelectedExprId(expressions[0].id);
-  } 
+  
   // get the expression
   const selectedExpr = expressions.find(e => e.id === selectedExprId)
   if (!selectedExpr) {

--- a/src/herbie/ErrorPlot.tsx
+++ b/src/herbie/ErrorPlot.tsx
@@ -200,7 +200,9 @@ function ErrorPlot() {
   const expressions = allExpressions.filter(e => !archivedExpressions.includes(e.id))
 
   // console.log('selectedExprId', selectedExprId)
-
+  if (expressions.length > 0 && selectedExprId === -1) {
+    setSelectedExprId(expressions[0].id);
+  } 
   // get the expression
   const selectedExpr = expressions.find(e => e.id === selectedExprId)
   if (!selectedExpr) {

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -305,7 +305,10 @@ function ExpressionTable() {
 
 
                   <div className="delete">
-                    <button onClick={() => setArchivedExpressions([...archivedExpressions, expression.id])}>
+                    <button onClick={() =>{ 
+                      setArchivedExpressions([...archivedExpressions, expression.id]);
+                      setSelectedExprId(-1);
+                      }}>
                     ╳
                     </button>
                   </div>

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -307,7 +307,10 @@ function ExpressionTable() {
                   <div className="delete">
                     <button onClick={() =>{ 
                       setArchivedExpressions([...archivedExpressions, expression.id]);
-                      setSelectedExprId(-1);
+                      const activeExp = activeExpressions.filter(id => id !== expression.id);
+                      if (activeExp.length > 0) {
+                        setSelectedExprId(activeExp[0]);
+                      } 
                       }}>
                     ╳
                     </button>


### PR DESCRIPTION
This bug fixes the issue when a selected expression is deleted and other expression exists still the error plot gives, 'Could not find expression with id 0'. So now whenever a selected expression is deleted we change selected id to the next expression in the list and by that the plot doesn't goes and stays until all expression are not deleted.