### PR TITLE
Ben expression export

### DIFF
--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import * as Contexts from './HerbieContext';
+import * as fpcorejs from './lib/fpcore';
+
+interface ExpressionExportProps {
+    expressionId: number;
+}
+
+const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
+    // Export the expression to a language of the user's choice
+    // (e.g. Python, C, etc.)
+    const [expressions, setExpressions] = Contexts.useGlobal(Contexts.ExpressionsContext);
+
+    // Get the expression text
+    const expressionText = expressions[props.expressionId].text;
+
+    // Get user choice
+    const [language, setLanguage] = React.useState("python");
+
+    const [exportCode, setExportCode] = React.useState("");
+
+    // Make server call to get translation when user submits
+
+    /*Example call:
+    
+    let translatedExpression = (await (await fetch('http://127.0.0.1:8000/api/translate', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))', lang: "asdf" }) })).json())
+    */
+    console.log(expressionText, language)
+    console.log(fpcorejs.mathjsToFPCore(expressionText))
+    console.log("Before fetch")
+    const callTranslate = () => {
+        fetch('http://127.0.0.1:8000/api/translate', {
+            method: 'POST',
+            body: JSON.stringify({
+                formula: fpcorejs.mathjsToFPCore(expressionText),
+                lang: language
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            setExportCode(data.result);
+        })
+        .catch(error => {
+            console.error('Error:', error);
+        });
+    }
+    React.useEffect(callTranslate, [expressionText, language])
+    setTimeout(callTranslate, 300)
+    // React.useEffect(() => {
+    //     // Make server call to get translation
+    //     fetch("http://127.0.0.1:8000/api/translate", {
+    //         method: "POST",
+    //         headers: {
+    //             "Content-Type": "application/json",
+    //         },
+    //         body: JSON.stringify({
+    //             expression: expressionText,
+    //             language: language,
+    //         }),
+    //     })
+    //         .then((response) => response.json())
+    //         .then((data) => {
+    //             setExportCode(data.code);
+    //         })
+    //         .catch((error) => {
+    //             console.error("Error:", error);
+    //         });
+    // }, [expressionText, language]);
+    
+
+    return (
+        <div>
+            {/* Choose language */}
+            <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+                <option value="python">Python</option>
+                <option value="c">C</option>
+                <option value="java">Java</option>
+            </select>
+
+            {/* Display the export code */}
+            <pre>{exportCode}</pre>
+
+            {/* Export button */}
+            
+
+        </div>
+    );
+};
+
+export default ExpressionExport;

--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -7,6 +7,9 @@ interface ExpressionExportProps {
 }
 
 const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
+
+    const supportedLanguages = ["python", "c", "fortran", "java", "julia", "matlab", "wls", "tex", "js"];
+    
     // Export the expression to a language of the user's choice
     // (e.g. Python, C, etc.)
     const [expressions, setExpressions] = Contexts.useGlobal(Contexts.ExpressionsContext);
@@ -15,25 +18,17 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
     const expressionText = expressions[props.expressionId].text;
 
     // Get user choice
-    const [language, setLanguage] = React.useState("python");
+    const [language, setLanguage] = React.useState(supportedLanguages[0]);
 
     const [exportCode, setExportCode] = React.useState("");
 
     // Make server call to get translation when user submits
-
-    /*Example call:
-    
-    let translatedExpression = (await (await fetch('http://127.0.0.1:8000/api/translate', { method: 'POST', body: JSON.stringify({ formula: '(FPCore (x) (- (sqrt (+ x 1)) (sqrt x)))', lang: "asdf" }) })).json())
-    */
-    console.log(expressionText, language)
-    console.log(fpcorejs.mathjsToFPCore(expressionText))
-    console.log("Before fetch")
     const callTranslate = () => {
         fetch('http://127.0.0.1:8000/api/translate', {
             method: 'POST',
             body: JSON.stringify({
                 formula: fpcorejs.mathjsToFPCore(expressionText),
-                lang: language
+                language: language
             })
         })
         .then(response => response.json())
@@ -45,23 +40,21 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
         });
     }
     React.useEffect(callTranslate, [expressionText, language])
-    setTimeout(callTranslate, 300)
 
     return (
         <div>
             {/* Choose language */}
             <select value={language} onChange={(e) => setLanguage(e.target.value)}>
-                <option value="python">Python</option>
-                <option value="c">C</option>
-                <option value="java">Java</option>
+                {supportedLanguages.map(lang => (
+                    <option key={lang} value={lang}>{lang}</option>
+                ))}
             </select>
 
             {/* Display the export code */}
             <pre>{exportCode}</pre>
 
             {/* Export button */}
-            
-
+        
         </div>
     );
 };

--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -46,27 +46,6 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
     }
     React.useEffect(callTranslate, [expressionText, language])
     setTimeout(callTranslate, 300)
-    // React.useEffect(() => {
-    //     // Make server call to get translation
-    //     fetch("http://127.0.0.1:8000/api/translate", {
-    //         method: "POST",
-    //         headers: {
-    //             "Content-Type": "application/json",
-    //         },
-    //         body: JSON.stringify({
-    //             expression: expressionText,
-    //             language: language,
-    //         }),
-    //     })
-    //         .then((response) => response.json())
-    //         .then((data) => {
-    //             setExportCode(data.code);
-    //         })
-    //         .catch((error) => {
-    //             console.error("Error:", error);
-    //         });
-    // }, [expressionText, language]);
-    
 
     return (
         <div>

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -222,7 +222,7 @@ function ExpressionTable() {
                 { value: 'localError', label: 'Local Error', component: <LocalError expressionId={expression.id} /> },
                 { value: 'derivationComponent', label: 'Derivation', component: <DerivationComponent expressionId={expression.id}/> },
                 { value: 'fpTaylorComponent', label: 'FPTaylor Analysis', component: <FPTaylorComponent expressionId={expression.id}/> },
-                { value: 'expressionExport', label: 'ExpressionExport', component: <ExpressionExport expressionId={expression.id}/> },
+                { value: 'expressionExport', label: 'Expression Export', component: <ExpressionExport expressionId={expression.id}/> },
               ];
             return (
               <div className={`expression-container ${expression.id === selectedExprId ? 'selected' : ''}`}>

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -9,11 +9,11 @@ import * as fpcore from './lib/fpcore'
 import { LocalError } from './LocalError/LocalError';
 import { DerivationComponent } from './DerivationComponent';
 import { FPTaylorComponent } from './FPTaylorComponent';
+import ExpressionExport from './ExpressionExport';
 import KaTeX from 'katex';
 import { DebounceInput } from 'react-debounce-input';
 
 import { addJobRecorder } from './HerbieUI';
-
 const math11 = require('mathjs11');
 
 import './ExpressionTable.css';
@@ -222,6 +222,7 @@ function ExpressionTable() {
                 { value: 'localError', label: 'Local Error', component: <LocalError expressionId={expression.id} /> },
                 { value: 'derivationComponent', label: 'Derivation', component: <DerivationComponent expressionId={expression.id}/> },
                 { value: 'fpTaylorComponent', label: 'FPTaylor Analysis', component: <FPTaylorComponent expressionId={expression.id}/> },
+                { value: 'expressionExport', label: 'ExpressionExport', component: <ExpressionExport expressionId={expression.id}/> },
               ];
             return (
               <div className={`expression-container ${expression.id === selectedExprId ? 'selected' : ''}`}>


### PR DESCRIPTION
This PR adds a front end component to the recent **translate** API endpoint in Herbie. 

In Odyssey, there is an additional tab in the expression table for Expression Export. In this tab, there are 9 supported languages that the user expression can be translated into: python, c, fortran, java, julia, matlab, wls, tex, and js.

Expression translated into python:

![image](https://github.com/herbie-fp/odyssey/assets/112049313/965dc4f7-34e7-49c6-aab7-ccc14d16d080)

Dropdown with language options:

![image](https://github.com/herbie-fp/odyssey/assets/112049313/d09e6ae2-1299-4919-b1d5-1a1c8e1b54ad)
