### PR TITLE
Ben speed versus accuracy pareto

### DIFF
--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -19,7 +19,6 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (expressionId) => {
     if (expressionText == null) {
         return <div>Expression not found</div>
     }
-  
     // Get user choice
     const [language, setLanguage] = useState(supportedLanguages[0]);
     const [exportCode, setExportCode] = useState<ExpressionExportResponse | null>(null);

--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -15,9 +15,6 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
     const [expressions, setExpressions] = Contexts.useGlobal(Contexts.ExpressionsContext);
 
     // Get the expression text
-
-    // const expressionText = expressions[props.expressionId].text;
-    // Removed ^^^
     const expression = expressions.find(expr => expr.id === props.expressionId);
 
     // Get user choice
@@ -42,9 +39,6 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
             console.error('Error:', error);
         });
     }
-
-    // React.useEffect(callTranslate, [expressionText, language])
-    // Removed ^^^
     React.useEffect(() => {
         if (expression) {
             callTranslate(expression.text);

--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -15,7 +15,10 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
     const [expressions, setExpressions] = Contexts.useGlobal(Contexts.ExpressionsContext);
 
     // Get the expression text
-    const expressionText = expressions[props.expressionId].text;
+
+    // const expressionText = expressions[props.expressionId].text;
+    // Removed ^^^
+    const expression = expressions.find(expr => expr.id === props.expressionId);
 
     // Get user choice
     const [language, setLanguage] = React.useState(supportedLanguages[0]);
@@ -23,7 +26,7 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
     const [exportCode, setExportCode] = React.useState("");
 
     // Make server call to get translation when user submits
-    const callTranslate = () => {
+    const callTranslate = (expressionText: string) => {
         fetch('http://127.0.0.1:8000/api/translate', {
             method: 'POST',
             body: JSON.stringify({
@@ -39,7 +42,14 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (props) => {
             console.error('Error:', error);
         });
     }
-    React.useEffect(callTranslate, [expressionText, language])
+
+    // React.useEffect(callTranslate, [expressionText, language])
+    // Removed ^^^
+    React.useEffect(() => {
+        if (expression) {
+            callTranslate(expression.text);
+        }
+    }, [expression, language]);
 
     return (
         <div>

--- a/src/herbie/SpeedVersusAccuracyPareto.tsx
+++ b/src/herbie/SpeedVersusAccuracyPareto.tsx
@@ -117,9 +117,6 @@ const SpeedVersusAccuracyPareto: React.FC<SpeedVersusAccuracyParetoProps> = (pro
     
     //get archived expressions
     const [archivedExpressions, setArchivedExpressions] = Contexts.useGlobal(Contexts.ArchivedExpressionsContext);
-    //filter expressions such that we only have the ones that are not archived
-
-    // const expressions = allExpressions.filter(e => !archivedExpressions.includes(e.id));
     
     const naiveExpression = allExpressions.find(e => e.text === spec.expression);
     if (naiveExpression === undefined) {
@@ -142,7 +139,6 @@ const SpeedVersusAccuracyPareto: React.FC<SpeedVersusAccuracyParetoProps> = (pro
     const [selectedExprId, setSelectedExprId] = Contexts.useGlobal(Contexts.SelectedExprIdContext);
 
     //filter selected expressions 
-    // const expressions = allExpressions.filter(e => !archivedExpressions.includes(e.id));
     const filteredExpressionIds = selectedExprIds.filter(e => !archivedExpressions.includes(e));
 
     // iterate through each expression to find its cost and accuracy and store them in an array as as [cost, accuracy] tuple

--- a/src/herbie/SpeedVersusAccuracyPareto.tsx
+++ b/src/herbie/SpeedVersusAccuracyPareto.tsx
@@ -118,11 +118,10 @@ const SpeedVersusAccuracyPareto: React.FC<SpeedVersusAccuracyParetoProps> = (pro
     //get archived expressions
     const [archivedExpressions, setArchivedExpressions] = Contexts.useGlobal(Contexts.ArchivedExpressionsContext);
     //filter expressions such that we only have the ones that are not archived
-    const expressions = allExpressions.filter(e => !archivedExpressions.includes(e.id));
-    
-    console.log('Expressions:', expressions);
 
-    const naiveExpression = expressions.find(e => e.text === spec.expression);
+    // const expressions = allExpressions.filter(e => !archivedExpressions.includes(e.id));
+    
+    const naiveExpression = allExpressions.find(e => e.text === spec.expression);
     if (naiveExpression === undefined) {
         return <div>Naive expression not found</div>
     }
@@ -142,16 +141,16 @@ const SpeedVersusAccuracyPareto: React.FC<SpeedVersusAccuracyParetoProps> = (pro
     // get the clicked on expression
     const [selectedExprId, setSelectedExprId] = Contexts.useGlobal(Contexts.SelectedExprIdContext);
 
+    //filter selected expressions 
+    // const expressions = allExpressions.filter(e => !archivedExpressions.includes(e.id));
+    const filteredExpressionIds = selectedExprIds.filter(e => !archivedExpressions.includes(e));
+
     // iterate through each expression to find its cost and accuracy and store them in an array as as [cost, accuracy] tuple
-    const points = selectedExprIds.map(id => {
-        const expression = expressions.find(e => e.id === id);
-        if (expression === undefined) {
-            return { cost: 0, accuracy: 0, id: 0 } as Point;
-        }
-        const cost = costs.find(c => c.expressionId === expression.id)?.cost;
-        const error = analyses.find(a => a.expressionId === expression.id)?.data.meanBitsError;
+    const points = filteredExpressionIds.map(id => {
+        const cost = costs.find(c => c.expressionId === id)?.cost;
+        const error = analyses.find(a => a.expressionId === id)?.data.meanBitsError;
         if (cost === undefined || error === undefined) {
-            return { cost: 0, accuracy: 0, id: 0 } as Point;
+            throw new Error(`Cost or error not found for expression ${id}`);
         }
         const accuracy = errorToAccuracy(error);
         return { cost: cost, accuracy: accuracy, id: id } as Point;


### PR DESCRIPTION
This PR fixes a bug found in the Pareto curve where the spec expression is included in the plot even after it is changed. 

Now, we properly filter out "archived" expressions. 


https://github.com/user-attachments/assets/f7b08096-e13a-4d36-b414-548c7fe6e9b4

