### PR TITLE
Ben cost to speedup

### DIFF
--- a/src/herbie/ExpressionTable.css
+++ b/src/herbie/ExpressionTable.css
@@ -112,7 +112,7 @@
   font-size: 10px;
 }
 
-.cost {
+.speedup {
   font-family: 'Ruda', serif;
   text-align: right;
   width: 80px; /* Fixed width to prevent resizing */
@@ -220,7 +220,7 @@
   margin-right: auto;
   margin-left: 6px;
 }
-.cost-header {
+.speedup-header {
   margin-right: 45px;
 }
 .error-header {

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -40,6 +40,9 @@ function ExpressionTable() {
   const [addExpression, setAddExpression] = useState('');
   const [expandedExpressions, setExpandedExpressions] = useState<number[]>([]);
   const [archivedExpressions, setArchivedExpressions] = HerbieContext.useGlobal(HerbieContext.ArchivedExpressionsContext)
+  const naiveExpression = expressions.find(e => e.text === spec.expression);
+  // get cost of naive expression
+  const naiveCost = cost.find(c => c.expressionId === naiveExpression?.id)?.cost;
 
   const herbiejs = addJobRecorder(herbiejsImport)
 
@@ -227,7 +230,7 @@ function ExpressionTable() {
         </div>
         <div className="compare-header">
         </div>
-        <div className="cost-header">
+        <div className="speedup-header">
           Speedup
         </div>
         <div className="error-header">
@@ -268,31 +271,9 @@ function ExpressionTable() {
                 : (analysisData.errors.reduce((acc: number, v: any) => {
                   return acc + v;
                 }, 0) / 8000).toFixed(2);
-            // const costData = cost.find((cost) => cost.expressionId === expression.id)?.cost;
-            // // const costResult = costData ? costData[0].toFixed(2) : '...';
-            // const costResult = !costData ? '...' : costData;
-            // console.log("cost data is " + costData + " and cost result is " + costResult);
-            
-            // find naive spec expression
-            const naiveExpression = expressions.find(e => e.text === spec.expression);
-            // get cost of naiveExpression
-            const naiveCost = cost.find(c => c.expressionId === naiveExpression?.id)?.cost;
-            // Error check. Throwing an Error breaks Odyssey so return null instead
-            if (naiveCost === undefined) {
-              console.error("Naive cost not found");
-              return null;
-            }
-            
-            const costResult = cost.find(c => c.expressionId === expression.id)?.cost;
-            // error check
-            if (costResult === undefined) {
-              console.error("Cost not found");
-              return null;
-            }
 
-            // speedup = naiveCost / costResult
-            // calculate speedup round to 1 decimal place
-            const speedup = (naiveCost / costResult).toFixed(1) + "x";
+            // cost of the expression
+            const costResult = cost.find(c => c.expressionId === expression.id)?.cost;
 
             const color = expressionStyles.find((style) => style.expressionId === expression.id)?.color
             const components = [
@@ -341,8 +322,8 @@ function ExpressionTable() {
                         <a className="copy-anchor">⧉</a>
                       </div>
                     </div>
-                  <div className="cost">
-                    {speedup}
+                  <div className="speedup">
+                    {naiveCost && costResult ? (naiveCost / costResult).toFixed(1) + "x" : "..."}
                   </div>
                   <div className="analysis">
                     {/* TODO: Not To hardcode number of bits*/}

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -228,7 +228,7 @@ function ExpressionTable() {
         <div className="compare-header">
         </div>
         <div className="cost-header">
-          Cost
+          Speedup
         </div>
         <div className="error-header">
           Accuracy
@@ -268,12 +268,31 @@ function ExpressionTable() {
                 : (analysisData.errors.reduce((acc: number, v: any) => {
                   return acc + v;
                 }, 0) / 8000).toFixed(2);
-            const costData = cost.find((cost) => cost.expressionId === expression.id)?.cost;
-            // const costResult = costData ? costData[0].toFixed(2) : '...';
-            const costResult = !costData ? '...' : costData;
-
-
+            // const costData = cost.find((cost) => cost.expressionId === expression.id)?.cost;
+            // // const costResult = costData ? costData[0].toFixed(2) : '...';
+            // const costResult = !costData ? '...' : costData;
             // console.log("cost data is " + costData + " and cost result is " + costResult);
+            
+            // find naive spec expression
+            const naiveExpression = expressions.find(e => e.text === spec.expression);
+            // get cost of naiveExpression
+            const naiveCost = cost.find(c => c.expressionId === naiveExpression?.id)?.cost;
+            // Error check. Throwing an Error breaks Odyssey so return null instead
+            if (naiveCost === undefined) {
+              console.error("Naive cost not found");
+              return null;
+            }
+            
+            const costResult = cost.find(c => c.expressionId === expression.id)?.cost;
+            // error check
+            if (costResult === undefined) {
+              console.error("Cost not found");
+              return null;
+            }
+
+            // speedup = naiveCost / costResult
+            // calculate speedup round to 1 decimal place
+            const speedup = (naiveCost / costResult).toFixed(1) + "x";
 
             const color = expressionStyles.find((style) => style.expressionId === expression.id)?.color
             const components = [
@@ -323,7 +342,7 @@ function ExpressionTable() {
                       </div>
                     </div>
                   <div className="cost">
-                    {costResult}
+                    {speedup}
                   </div>
                   <div className="analysis">
                     {/* TODO: Not To hardcode number of bits*/}


### PR DESCRIPTION
This PR changes the Cost representation from a constant value to a multiplier with respect to the original expression. Multiplier value is rounded to 1 decimal point. 

Before:

![image](https://github.com/user-attachments/assets/788c07af-c6cb-4173-88b9-c56c4f97ea61)

After:

![image](https://github.com/user-attachments/assets/e15acc68-ea13-4ddb-91da-5c54a07b002f)

