### PR TITLE
Ben cost accuracy columns swapped

### DIFF
--- a/src/herbie/ExpressionTable.css
+++ b/src/herbie/ExpressionTable.css
@@ -114,7 +114,7 @@
 
 .analysis {
   font-family: 'Ruda', serif;
-  text-align: right;
+  margin-right: -15px;
   width: 80px; /* Fixed width to prevent resizing */
   display: flex;
   align-items: center; /* Center content vertically */
@@ -221,7 +221,7 @@
   margin-left: 6px;
 }
 .error-header {
-  margin-right: 45px;
+  margin-right: 35px;
 }
 .speedup-header {
   margin-right: 86px;

--- a/src/herbie/ExpressionTable.css
+++ b/src/herbie/ExpressionTable.css
@@ -112,7 +112,7 @@
   font-size: 10px;
 }
 
-.speedup {
+.analysis {
   font-family: 'Ruda', serif;
   text-align: right;
   width: 80px; /* Fixed width to prevent resizing */
@@ -121,7 +121,7 @@
   justify-content: flex-end; /* Align text to the right */
 }
 
-.analysis {
+.speedup {
   font-family: 'Ruda', serif;
   text-align: right;
   width: 80px; /* Fixed width to prevent resizing */
@@ -220,10 +220,10 @@
   margin-right: auto;
   margin-left: 6px;
 }
-.speedup-header {
+.error-header {
   margin-right: 45px;
 }
-.error-header {
+.speedup-header {
   margin-right: 86px;
 }
 

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -230,11 +230,11 @@ function ExpressionTable() {
         </div>
         <div className="compare-header">
         </div>
-        <div className="speedup-header">
-          Speedup
-        </div>
         <div className="error-header">
           Accuracy
+        </div>
+        <div className="speedup-header">
+          Speedup
         </div>
         <div className="buttons-header">
 
@@ -322,12 +322,12 @@ function ExpressionTable() {
                         <a className="copy-anchor">⧉</a>
                       </div>
                     </div>
-                  <div className="speedup">
-                    {naiveCost && costResult ? (naiveCost / costResult).toFixed(1) + "x" : "..."}
-                  </div>
                   <div className="analysis">
                     {/* TODO: Not To hardcode number of bits*/}
                     {analysisResult ? (100 - (parseFloat(analysisResult)/64)*100).toFixed(1) + "%" : "..."}
+                  </div>
+                  <div className="speedup">
+                    {naiveCost && costResult ? (naiveCost / costResult).toFixed(1) + "x" : "..."}
                   </div>
                   <div className="herbie">
                     <button onClick={() => handleImprove(expression)}>


### PR DESCRIPTION
This PR swaps the accuracy and cost speedup columns, and eliminates excess white space between them.

![image](https://github.com/user-attachments/assets/80d257ce-ccaa-41e3-b37e-242f484823f7)
