### PR TITLE
link fix from bad merge

### DIFF
--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -208,6 +208,10 @@ function ExpressionTable() {
       newDerivations.push(newDerivation);
     }
 
+    
+    const path = suggested.path;
+    setAlternativesJobResponse({ expressionId: newExpressions.map(expression => expression.id), path: path });
+    
     setExpressions([...newExpressions, ...expressions]);
     setDerivations([...newDerivations, ...derivations]);
     setCompareExprIds([...compareExprIds, ...newExpressions.map(e => e.id)]);


### PR DESCRIPTION
PR fixes a bug where the link displayed is undefined. Original code was overridden in a bad merge.

Now link correctly directs user to the herbie timeline page!