### PR TITLE
add fpcore to expression export column

### DIFF
--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -8,7 +8,7 @@ interface ExpressionExportProps {
 }
 
 const ExpressionExport: React.FC<ExpressionExportProps> = (expressionId) => {
-    const supportedLanguages = ["python", "c", "fortran", "java", "julia", "matlab", "wls", "tex", "js"];
+    const supportedLanguages = ["fpcore", "python", "c", "fortran", "java", "julia", "matlab", "wls", "tex", "js"];
 
     // Export the expression to a language of the user's choice
     const [expressions] = Contexts.useGlobal(Contexts.ExpressionsContext);
@@ -42,7 +42,11 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (expressionId) => {
     };
     // Update the expressionText
     React.useEffect(() => {
-        translateExpression();
+        if (language !== "fpcore") {
+            translateExpression();
+        } else {
+            setExportCode({ language: "fpcore", result: expressionText?.text });
+        }
     }, [expressionText, language]);
 
     return (


### PR DESCRIPTION
This PR adds fpcore as a language into the expression export column. It is now the default language to appear. 

![image](https://github.com/user-attachments/assets/89dad67e-ad53-46a1-ab1f-f952bb439edf)
![image](https://github.com/user-attachments/assets/14a2ba71-7167-429b-a0dd-32f1569116db)
