### PR TITLE
Add exact error to Local Error tree.

### DIFF
--- a/src/herbie/HerbieTypes.ts
+++ b/src/herbie/HerbieTypes.ts
@@ -102,6 +102,7 @@ export interface LocalErrorTree {
   e: string
   children: LocalErrorTree[]
   'avg-error': string
+  'exact-error': string
 }
 
 export class AverageLocalErrorAnalysis {

--- a/src/herbie/LocalError/LocalError.tsx
+++ b/src/herbie/LocalError/LocalError.tsx
@@ -13,16 +13,25 @@ function localErrorTreeAsMermaidGraph(tree: types.LocalErrorTree, bits: number) 
   let counter = 0
 
   const isLeaf = (n: types.LocalErrorTree ) => n['children'].length === 0
-  const formatName = (id : string, name : string, err: string) => id + '[<span class=nodeLocalError title=' + err + '>' + name + '</span>]'
+
+  function formatName(id: string, name: string, avg_err: string, exact_err: string) {
+    var exact_err_txt = ""
+    if (exact_err != undefined) {
+      exact_err_txt = `, Exact Error:  ${exact_err}`
+    }
+    const title = `'Average Error: ${avg_err}${exact_err_txt}'`
+    return id + '[<span class=nodeLocalError title=' + title + '>' + name + '</span>]'
+  }
 
   function loop(n : types.LocalErrorTree) {
     const name = n['e']
     const children = n['children']
     const avg_error = n['avg-error']
+    const exact_error = n['exact-error']
 
     // node name
     const id = 'N' + counter++
-    const nodeName = formatName(id, name, avg_error)
+    const nodeName = formatName(id, name, avg_error, exact_error)
 
     // descend through AST
     for (const c in children) {
@@ -44,7 +53,8 @@ function localErrorTreeAsMermaidGraph(tree: types.LocalErrorTree, bits: number) 
   if (isLeaf(tree)) {
     const name = tree['e']
     const avg_error = tree['avg-error']
-    edges.push(formatName('N0', name, avg_error))
+    const exact_error = tree['exact-error']
+    edges.push(formatName('N0', name, avg_error, exact_error))
   }
 
   // List colors


### PR DESCRIPTION
This PR accompanies this Herbie [PR]( https://github.com/herbie-fp/herbie/pull/984) to add basic support for displaying the exact error in the title attributed of the local error tree.


<img width="298" alt="Screenshot 2024-09-04 at 2 10 24 PM" src="https://github.com/user-attachments/assets/40547068-20ef-4ecf-a346-c394c1a0abe3">
