### PR TITLE
Add Infinity to map of CONSTANTS.

### DIFF
--- a/src/herbie/lib/fpcore.ts
+++ b/src/herbie/lib/fpcore.ts
@@ -10,7 +10,7 @@ export interface mathjs extends String { }
 interface fpcore extends String { }
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
-const CONSTANTS : {[key: string]: string} = { "PI": "real", "E": "real", "TRUE": "bool", "FALSE": "bool" }
+const CONSTANTS : {[key: string]: string} = { "PI": "real", "E": "real", "TRUE": "bool", "FALSE": "bool", "INFINITY": "real"}
 
 const FUNCTIONS : {[key: string]: [string[], string]}= {}
 


### PR DESCRIPTION
This Fixes an issue in `getVarnamesMathJS` for the `mathjs` expression:
```mathjs
(((100.0 * (pow(1.0 + (i / n), n) - 1.0)) / (i / n)) <= 0.0) ? ((- -100.0) * (expm1(log1p(i / n) * n) / (i / n))) : ((((100.0 * (pow(1.0 + (i / n), n) - 1.0)) / (i / n)) <= INFINITY) ? (fma(pow((i / n) + 1.0, n), 100.0, -100.0) / (i / n)) : (100.0 * n))
```
Which incorrectly adds `INFINITY` as a variable. 

Adding `INFINITY` as a CONSTANT fixes this issue.