### PR TITLE
Fix percent, hide invalid information.

### DIFF
--- a/src/herbie/LocalError/LocalError.tsx
+++ b/src/herbie/LocalError/LocalError.tsx
@@ -26,15 +26,17 @@ function localErrorTreeAsMermaidGraph(tree: types.LocalErrorTree, bits: number, 
       explanation_str = ` <br /> Error Code : ${_explanation}`
     }
     var difference_str = ` <br /> Error R - F : ${displayError(abs_error_difference)}`
+    var accuracy_str = ""
+    if (!(abs_error_difference === "equal")) {
+      accuracy_str = ` <br /> Percent Accuracy : ${Number(percent).toPrecision(4)}%${explanation_str}`
+    }
     if (abs_error_difference === "invalid" 
       || abs_error_difference === "unsamplable" 
       || abs_error_difference === "equal") {
       console.debug(`abs_error was 'equal, 'invalid, or 'unsamplable: ${difference_str}`)
+      // Hide invalid information.
       difference_str = ""
-    }
-    var accuracy_str = ""
-    if (!(abs_error_difference === "equal")) {
-      accuracy_str = ` <br /> Percent Accuracy : ${herbiejs.displayNumber(Number(percent))}%${explanation_str}`
+      accuracy_str = ""
     }
     const tooltipContent = `'Correct R : ${displayError(exact_err)} <br /> Approx F : ${displayError(approx_value)}${difference_str}${accuracy_str}'`;
     return id + '[<span class=nodeLocalError data-tooltip-id=node-tooltip data-tooltip-html=' + tooltipContent + '>' + name + '</span>]'


### PR DESCRIPTION
This PR fixes percent displaying `2e%` for high percent values like 99% and 100%. Also, hides `'invalid` information which is triggered by a bug within Rival.