### PR TITLE
Calling server side pcontext

### DIFF
--- a/src/herbie/HerbieTypes.ts
+++ b/src/herbie/HerbieTypes.ts
@@ -87,10 +87,12 @@ export type expressionError = number
 // LATER probably don't need ExpressionError in this
 export class Sample {
   constructor(
+      public readonly job: string,
       public readonly points: [ordinalPoint, expressionError][],
       public readonly specId: number,
       public readonly inputRangesId: number,
       public readonly id: number) {
+    this.job = job;
     this.points = points;
     this.specId = specId;
     this.inputRangesId = inputRangesId;

--- a/src/herbie/HerbieUI.tsx
+++ b/src/herbie/HerbieUI.tsx
@@ -310,9 +310,11 @@ function HerbieUIInner() {
         return  // should never get here
       }
 
-      const sample_points = (await herbiejs.getSample(fpCore, serverUrl)).points;
+      const sample_json = (await herbiejs.getSample(fpCore, serverUrl));
+      console.log(`SAMPLE:${sample_json['job']}`)
+      const sample_points = sample_json.points;
       // always create a new sample with this spec and these input ranges
-      const sample = new Sample(sample_points, spec.id, inputRanges.id, nextId(samples))
+      const sample = new Sample(sample_json['job']!, sample_points, spec.id, inputRanges.id, nextId(samples))
       setSamples([...samples, sample]);
       console.debug(`Sampled spec ${spec.id} for input ranges ${inputRanges.id}:`, sample)
     }
@@ -362,7 +364,7 @@ function HerbieUIInner() {
           // HACK to make sampling work on Herbie side
           const vars = fpcorejs.getVarnamesMathJS(expression.text)
           const specVars = fpcorejs.getVarnamesMathJS(spec.expression)
-          const modSample = new Sample(sample.points.map(([x, y], _) => [x.filter((xi, i) => vars.includes(specVars[i])), y]), sample.specId, sample.inputRangesId, sample.id)
+          const modSample = new Sample(sample.job, sample.points.map(([x, y], _) => [x.filter((xi, i) => vars.includes(specVars[i])), y]), sample.specId, sample.inputRangesId, sample.id)
           const localErrorTree = (await herbiejs.analyzeLocalError(fpcorejs.mathjsToFPCore(expression.text, /*fpcorejs.mathjsToFPCore(spec.expression)*/), modSample, serverUrl))
           return new Types.AverageLocalErrorAnalysis(expression.id, sample.id, localErrorTree)
           // updates.push(new Types.AverageLocalErrorAnalysis(expression.id, sample.id, localErrorTree))

--- a/src/herbie/lib/herbiejs.ts
+++ b/src/herbie/lib/herbiejs.ts
@@ -9,6 +9,7 @@ interface HerbieResponse {
   mathjs?: string;
   points: any[];
   tree?: types.LocalErrorTree;
+  job?: string;
 }
 
 const getHerbieApiAsync = async (
@@ -226,8 +227,7 @@ export const analyzeExpression = async (
   };
 
 
-
-  const pointsAndErrors = ((await getHerbieApi(host, 'analyze', { formula: fpcore, sample: sample.points, seed: 5 }, true)) as AnalyzeResponse).points;
+  const pointsAndErrors = ((await getHerbieApi(host, 'analyze-hashed', { formula: fpcore, sample_hash: sample['job'], seed: 5 }, true)) as AnalyzeResponse).points;
   const ordinalSample = pointsAndErrors.map(p => p[0].map((v: number) => ordinalsjs.floatToApproximateOrdinal(v)));
 
   // console.log('first 10 pointsAndErrors', pointsAndErrors.map(([point, error]) => point).slice(0, 10));


### PR DESCRIPTION
Using the job IDs already sent by the server we don't need to send large pcontext to the server for `/analyze` calls. This requires [Herbie PR](https://github.com/herbie-fp/herbie/pull/1054). But this does seem to fix the examples mentioned in these Issues #183 [#1048](https://github.com/herbie-fp/herbie/issues/1048).