### PR TITLE
export shareable link

### DIFF
--- a/src/herbie/SerializeStateComponent.tsx
+++ b/src/herbie/SerializeStateComponent.tsx
@@ -167,14 +167,22 @@ function SerializeStateComponent(props: exportStateProps) {
                   // "Authorization": token  
               }
           });
-          const url = response.data.files[fileName].raw_url;
-          setGistUrl(url);
-          // copy gist link to clipboard
-          navigator.clipboard.writeText(url);
+
+          const gistId = response.data.id;
+          const shareableLink = `https://herbie-fp.github.io/odyssey/?gist=${gistId}`;
+          setGistUrl(shareableLink); // <-- instead of raw_url
+          navigator.clipboard.writeText(shareableLink);
+
+          // OLD: Copy gist raw_url
+          // const url = response.data.files[fileName].raw_url;
+          // setGistUrl(url);
+          // // copy gist link to clipboard
+          // navigator.clipboard.writeText(url);
 
           setCopied(true); 
           setHasGeneratedGist(true);
-          console.log("Gist Created:", url);
+          console.log("Gist Raw Url:", response.data.files[fileName].raw_url);
+          console.log("Gist Shareable Link:", shareableLink);
       } catch (error) {
           console.error("Error creating Gist:", error);
       }


### PR DESCRIPTION
Currently, the **export** feature shares the raw_url to the user.

This PR replaces the raw_url with a shareable Odyssey link. 

Originally, the web browser link was: https://herbie-fp.github.io/odyssey/
Now, we include the unique gist id: https://herbie-fp.github.io/odyssey/?gist=unique-gist-id-12345 

For example:
![image](https://github.com/user-attachments/assets/40814b04-a6bf-45b3-ac3d-4c8b29f60c53)