### PR TITLE
Derivations histories

### DIFF
--- a/src/herbie/DerivationComponent.tsx
+++ b/src/herbie/DerivationComponent.tsx
@@ -1,47 +1,12 @@
 import Latex from 'react-latex-next';
 import * as HerbieContext from './HerbieContext';
 import './DerivationComponent.css';
-import { ReactNode, useEffect } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { DerivationNode, ProofStep } from './HerbieTypes';
-import ReactDOMServer from 'react-dom/server';
-import KaTeX from 'katex';
-import { expressionToTex } from './ExpressionTable';
-import * as fpcorejs from './lib/fpcore'
 
-// Function to convert FPCore to TeX (simplified version)
-function fpCoreToTeX(expr: string, options?: { loc: any; color: any; }) {
-  // Handle colored output for specific locations if provided
-  if (options && options.loc && options.loc.length > 0 && options.color) {
-    // This is a simplified approach - a real implementation would navigate to the specific location
-    // and wrap just that part in color
-    return `\\color{${options.color}}{${
-      expr
-        .replace(/\(FPCore \(x\)\s+/g, '')
-        .replace(/\)\)/g, '}')
-        .replace(/\(\-\.f64/g, '(')
-        .replace(/\(\+\.f64/g, '(')
-        .replace(/\(\/\.f64/g, '\\frac{')
-        .replace(/\(sqrt\.f64 \(\+\.f64 x 1\)\)/g, '\\sqrt{x + 1}')
-        .replace(/\(sqrt\.f64 \(\+\.f64 1 x\)\)/g, '\\sqrt{1 + x}')
-        .replace(/\(sqrt\.f64 x\)/g, '\\sqrt{x}')
-        .replace(/\#s\(approx \(- \(\+ 1 x\) x\) 1\)/g, '1')
-        .replace(/\(\+\.f64 1 x\)/g, '(1 + x)')
-    }}`;
-  }
-  
-  // Basic conversion (highly simplified)
-  return expr
-    .replace(/\(FPCore \(x\)\s+/g, '')
-    .replace(/\)\)/g, '}')
-    .replace(/\(\-\.f64/g, '(')
-    .replace(/\(\+\.f64/g, '(')
-    .replace(/\(\/\.f64/g, '\\frac{')
-    .replace(/\(sqrt\.f64 \(\+\.f64 x 1\)\)/g, '\\sqrt{x + 1}')
-    .replace(/\(sqrt\.f64 \(\+\.f64 1 x\)\)/g, '\\sqrt{1 + x}')
-    .replace(/\(sqrt\.f64 x\)/g, '\\sqrt{x}')
-    .replace(/\#s\(approx \(- \(\+ 1 x\) x\) 1\)/g, '1')
-    .replace(/\(\+\.f64 1 x\)/g, '(1 + x)');
-}
+import KaTeX from 'katex';
+
+import * as herbiejs from './lib/herbiejs';
 
 // Format accuracy for display
 function formatAccuracy(val: number, bits = null, unit = '%') {
@@ -49,10 +14,10 @@ function formatAccuracy(val: number, bits = null, unit = '%') {
 }
 
 // Render a proof to HTML
-function renderProof(proof: ProofStep[], options = {}) {
+async function renderProof(proof: ProofStep[], serverUrl: string, options = {}) {
   const proofSteps = proof
     .filter(step => step.direction !== "goal")
-    .map(step => {
+    .map(async (step,i) => {
       // Convert direction to human-readable form
       const dirText = step.direction === "rtl" ? "right to left" : 
                       step.direction === "ltr" ? "left to right" : "";
@@ -61,17 +26,13 @@ function renderProof(proof: ProofStep[], options = {}) {
       const err = step.error;
       
       return (
-        <li key={step.rule + Math.random()}>
+        <li key={step.rule + "_" + i}>
           <p>
             <code title={dirText}>{step.rule}</code>
             <span className="error">{err}</span>
           </p>
-          <div className="math" dangerouslySetInnerHTML={{ 
-            __html: `\\[\\leadsto ${fpCoreToTeX(step.program, { 
-              loc: step.loc, 
-              color: "blue" 
-            })}\\]` 
-          }} />
+          { await texFromFPCoreHTML(step.program, serverUrl) }
+
         </li>
       );
     });
@@ -81,13 +42,41 @@ function renderProof(proof: ProofStep[], options = {}) {
       <div className="proof">
         <details>
           <summary>Step-by-step derivation</summary>
-          <ol>{proofSteps}</ol>
+          <ol>{await Promise.all(proofSteps)}</ol>
         </details>
       </div>
     </li>
   );
 }
 
+
+// Make server call to get tex version of expression
+const expressionToTexFPCore = async (expression: string, serverUrl: string) => {
+  try {
+    const response = await herbiejs.translateFpcoreToLanguage(
+      expression,
+      "tex",
+      serverUrl
+    );
+
+    // result starts with "exp(x) =" (all vars ", " separated), slice that off
+    const pre = response.result.split('=')[0];
+    return KaTeX.renderToString(response.result.slice(pre.length + 1), { throwOnError: false }
+    )
+  } catch (err: any) {
+    if ((err as Error).toString().includes("approx")) {
+      // If the error is about approx, we are still waiting for https://github.com/FPBench/FPBench/issues/145
+      return "LaTeX rendering of approx nodes is not yet supported. Please try again later.";
+    }
+    return (err as Error).toString()
+  }
+};
+
+async function texFromFPCoreHTML(expr: string, serverUrl: string): Promise<ReactNode> {
+  return <div className="math" dangerouslySetInnerHTML={{
+    __html: await expressionToTexFPCore(expr.replaceAll('.f64', ''), serverUrl), 
+  }} />;
+} 
 
 // Render history recursively
 async function renderHistory(altn: DerivationNode, options = {}, serverUrl: string): Promise<ReactNode[]> {
@@ -99,18 +88,11 @@ async function renderHistory(altn: DerivationNode, options = {}, serverUrl: stri
     const err2 = formatAccuracy(altn["training-error"]);
     
     items.push(
-      <li key="start">
+      <li>
         <p>
           Initial program <span className="error" title={`${err2} on training set`}>{err}</span>
         </p>        
-        <div className="math" dangerouslySetInnerHTML={{
-            //__html:  KaTeX.renderToString(`\\[${fpCoreToTeX(altn.program)}\\]`, { throwOnError: false })
-            __html:  KaTeX.renderToString(
-              await expressionToTex(altn.program, fpcorejs.getVarnamesMathJS(altn.program).length, serverUrl), { throwOnError: false }
-            )
-          }}
-        />
-        await expressionToTex(expression, fpcorejs.getVarnamesMathJS(expression).length, serverUrl)
+        { await texFromFPCoreHTML(altn.program, serverUrl) }
       </li>
     );
   }
@@ -121,7 +103,7 @@ async function renderHistory(altn: DerivationNode, options = {}, serverUrl: stri
     }
     
     // Add the preprocessing step
-    items.push(<li key="preprocess">Add Preprocessing</li>);
+    items.push(<li>Add Preprocessing</li>);
   }
   else if (altn.type === "taylor") {
     // Add the previous items
@@ -131,20 +113,9 @@ async function renderHistory(altn: DerivationNode, options = {}, serverUrl: stri
     
     // Add Taylor expansion step
     items.push(
-      <li key="taylor">
+      <li>
         <p>Taylor expanded in {altn.var} around {altn.pt}</p>
-        <Latex>     
-          {
-            ReactDOMServer.renderToString(
-              <div className="math" dangerouslySetInnerHTML={{ 
-                __html: `\\[\\leadsto ${fpCoreToTeX(altn.program, { 
-                  loc: altn.loc, 
-                  color: "blue" 
-                })}\\]` 
-              }} />
-            )
-          }
-        </Latex>
+        { await texFromFPCoreHTML(altn.program, serverUrl) }
       </li>
     );
   }
@@ -156,7 +127,7 @@ async function renderHistory(altn: DerivationNode, options = {}, serverUrl: stri
     
     // Add proof if it exists
     if (altn.proof && altn.proof.length > 0) {
-      items.push(renderProof(altn.proof, options));
+      items.push(await renderProof(altn.proof, serverUrl, options));
     }
     
     // Add rewrite rule application step
@@ -164,16 +135,50 @@ async function renderHistory(altn: DerivationNode, options = {}, serverUrl: stri
     const err2 = formatAccuracy(altn["training-error"]);
     
     items.push(
-      <li key="rr">
+      <li>
         <p>
           Applied rewrites<span className="error" title={`${err2} on training set`}>{err}</span>
         </p>
-        <div className="math" dangerouslySetInnerHTML={{ 
-          __html: `\\[\\leadsto ${fpCoreToTeX(altn.program, { 
-            loc: altn.loc, 
-            color: "blue" 
-          })}\\]` 
-        }} />
+        { await texFromFPCoreHTML(altn.program, serverUrl) }
+      </li>
+    );
+  }
+  else if (altn.type === "regimes") {
+    // For each regime, render the condition as "if ..." and then the derivation for that branch
+
+    items.push(
+      <li>
+        <ol>
+          {await Promise.all(altn.conditions.map(async (condition, i) => (
+            <div key={i}>
+              <h3 className="condition">if {condition.join(" and ")}</h3>
+              <div>
+                {await Promise.all(altn.prevs.map(async (prev, j) => (
+                  <div key={j}>
+                    {await renderHistory(prev, options, serverUrl)}
+                  </div>
+                )))}
+              </div>
+            </div>
+          )))}
+        </ol>
+      </li>
+    );
+  }
+  else if (altn.type === "final-simplify") {
+    // Add the previous items
+    if (altn.prev) {
+      items.push(...await renderHistory(altn.prev, options, serverUrl));
+    }
+    
+    // Add final simplification step
+    const err = formatAccuracy(altn.error);
+    const err2 = formatAccuracy(altn["training-error"]);
+    
+    items.push(
+      <li>
+        <p>Final simplification<span className="error" title={`${err2} on training set`}>{err}</span></p>
+        { await texFromFPCoreHTML(altn.program, serverUrl) }
       </li>
     );
   }
@@ -182,101 +187,16 @@ async function renderHistory(altn: DerivationNode, options = {}, serverUrl: stri
 }
 
 // Main component for rendering derivations
-const DerivationRenderer = (derivation: DerivationNode) => {
-  const [serverUrl,] = HerbieContext.useGlobal(HerbieContext.ServerContext)
-
-  // // Example JSON data
-  // const exampleDerivation: DerivationNode = {
-  //   "error": 0.16362048906511412,
-  //   "preprocessing": [],
-  //   "prev": {
-  //     "error": 0.16362048906511412,
-  //     "loc": [1],
-  //     "prev": {
-  //       "error": "N/A",
-  //       "loc": [1],
-  //       "prev": {
-  //         "error": 29.28147582053326,
-  //         "loc": [],
-  //         "prev": {
-  //           "error": 29.900400659788048,
-  //           "preprocessing": [],
-  //           "prev": {
-  //             "error": 29.900400659788048,
-  //             "program": "(FPCore (x) (-.f64 (sqrt.f64 (+.f64 x 1)) (sqrt.f64 x)))",
-  //             "training-error": 29.900400659788048,
-  //             "type": "start"
-  //           },
-  //           "program": "(FPCore (x) (-.f64 (sqrt.f64 (+.f64 x 1)) (sqrt.f64 x)))",
-  //           "training-error": 29.900400659788048,
-  //           "type": "add-preprocessing"
-  //         },
-  //         "program": "(FPCore (x)\n (/.f64 (-.f64 (+.f64 1 x) x) (+.f64 (sqrt.f64 x) (sqrt.f64 (+.f64 1 x)))))",
-  //         "proof": [
-  //           {
-  //             "direction": "goal",
-  //             "error": 29.900400659788048,
-  //             "loc": [],
-  //             "program": "(FPCore (x) (-.f64 (sqrt.f64 (+.f64 x 1)) (sqrt.f64 x)))",
-  //             "rule": "#f",
-  //             "tag": " ↑ 0 ↓ 0"
-  //           },
-  //           {
-  //             "direction": "ltr",
-  //             "error": "N/A",
-  //             "loc": [],
-  //             "program": "(FPCore (x) (- (sqrt.f64 (+.f64 x 1)) (sqrt.f64 x)))",
-  //             "rule": "lift--.f64",
-  //             "tag": " ↑ N/A ↓ N/A"
-  //           },
-  //           {
-  //             "direction": "ltr",
-  //             "error": "N/A",
-  //             "loc": [],
-  //             "program": "(FPCore (x)\n (/\n  (-\n   (* (sqrt.f64 (+.f64 x 1)) (sqrt.f64 (+.f64 x 1)))\n   (* (sqrt.f64 x) (sqrt.f64 x)))\n  (+ (sqrt.f64 (+.f64 x 1)) (sqrt.f64 x))))",
-  //             "rule": "flip--",
-  //             "tag": " ↑ N/A ↓ N/A"
-  //           }
-  //         ],
-  //         "training-error": 29.28147582053326,
-  //         "type": "rr"
-  //       },
-  //       "program": "(FPCore (x) (/.f64 1 (+.f64 (sqrt.f64 x) (sqrt.f64 (+.f64 1 x)))))",
-  //       "pt": "0",
-  //       "training-error": "N/A",
-  //       "type": "taylor",
-  //       "var": "x"
-  //     },
-  //     "program": "(FPCore (x)\n (/.f64\n  #s(approx (- (+ 1 x) x) 1)\n  (+.f64 (sqrt.f64 x) (sqrt.f64 (+.f64 1 x)))))",
-  //     "proof": [
-  //       {
-  //         "direction": "goal",
-  //         "error": 0.16362048906511412,
-  //         "loc": [],
-  //         "program": "(FPCore (x) (/.f64 1 (+.f64 (sqrt.f64 x) (sqrt.f64 (+.f64 1 x)))))",
-  //         "rule": "#f",
-  //         "tag": " ↑ 0 ↓ 0"
-  //       }
-  //     ],
-  //     "training-error": 0.16362048906511412,
-  //     "type": "rr"
-  //   },
-  //   "program": "(FPCore (x)\n (/.f64\n  #s(approx (- (+ 1 x) x) 1)\n  (+.f64 (sqrt.f64 x) (sqrt.f64 (+.f64 1 x)))))",
-  //   "training-error": 0.16362048906511412,
-  //   "type": "add-preprocessing"
-  // };
+const DerivationRenderer = async (derivation: DerivationNode, serverUrl: string) => {
 
   return (
-    <div className="container p-4 mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Floating-Point Expression Optimization</h1>
-      
+    <div className="container p-4 mx-auto">      
       <div className="bg-white rounded-lg p-4 shadow">
         <div id="history">
           <ol>
             {await renderHistory(
               derivation, 
               {
-                fpCoreToTeX,
                 formatAccuracy
               },
               serverUrl
@@ -284,34 +204,14 @@ const DerivationRenderer = (derivation: DerivationNode) => {
           </ol>
         </div>
       </div>
-      
-      <style>{`
-        .math {
-          overflow-x: auto;
-        }
-        .error {
-          margin-left: 0.5rem;
-          color: #4299e1;
-          cursor: help;
-        }
-        .proof {
-          margin: 0.5rem 0;
-        }
-        details summary {
-          cursor: pointer;
-          color: #4a5568;
-          font-weight: 500;
-        }
-        .condition {
-          font-style: italic;
-        }
-      `}</style>
     </div>
   );
 };
 
 const DerivationComponent = ({ expressionId }: { expressionId: number }) => {
   const [derivations, setDerivations] = HerbieContext.useGlobal(HerbieContext.DerivationsContext)
+  const [body, setBody] = useState(<Latex>Loading...</Latex>);
+  const [serverUrl,] = HerbieContext.useGlobal(HerbieContext.ServerContext)
 
   let selectedDerivation = derivations.find(d => d.id === expressionId)
   if (!selectedDerivation) {
@@ -319,15 +219,17 @@ const DerivationComponent = ({ expressionId }: { expressionId: number }) => {
   }
 
   useEffect(() => {
-    async function() {
-      selectedDerivation?.derivation ?
-      await DerivationRenderer(selectedDerivation.derivation) : 
-      <Latex> 
-        {
-          selectedDerivation.history
-        }
-      </Latex>
+    async function getBody() {
+      const newBody = selectedDerivation?.derivation ?
+        await DerivationRenderer(selectedDerivation.derivation, serverUrl) : 
+        <Latex> 
+          {
+            selectedDerivation?.history || "No history available for this expression."
+          }
+        </Latex>
+      setBody(newBody);
     }
+    getBody();
   }, []);
 
   let currentExpressionId: number | undefined = selectedDerivation.id
@@ -352,13 +254,7 @@ const DerivationComponent = ({ expressionId }: { expressionId: number }) => {
 
   return <div>
       {
-        selectedDerivation.derivation ?
-        await DerivationRenderer(selectedDerivation.derivation) : 
-        <Latex> 
-          {
-            selectedDerivation.history
-          }
-        </Latex>
+        body
       }
   </div>
 };

--- a/src/herbie/ExpressionExport.tsx
+++ b/src/herbie/ExpressionExport.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import * as HerbieContext from './HerbieContext';
 import * as fpcorejs from './lib/fpcore';
-import { analyzeExpressionExport, ExpressionExportResponse } from './lib/herbiejs';
+import { translateFpcoreToLanguage, ExpressionExportResponse } from './lib/herbiejs';
 
 interface ExpressionExportProps {
     expressionId: number;
@@ -28,7 +28,7 @@ const ExpressionExport: React.FC<ExpressionExportProps> = (expressionId) => {
     // Make server call to get translation when user submits
     const translateExpression = async () => {
         try {
-            const response = await analyzeExpressionExport(
+            const response = await translateFpcoreToLanguage(
                 fpcorejs.mathjsToFPCore(expressionText?.text),
                 language,
                 serverUrl

--- a/src/herbie/ExpressionTable.tsx
+++ b/src/herbie/ExpressionTable.tsx
@@ -26,7 +26,7 @@ import LinkToReports from './LinkToReports';
 // Make server call to get tex version of expression
 export const expressionToTex = async (expression: fpcorejs.mathjs, numVars: number, serverUrl: string) => {
   try {
-    const response = await herbiejs.analyzeExpressionExport(
+    const response = await herbiejs.translateFpcoreToLanguage(
       fpcorejs.mathjsToFPCore(expression),
       "tex",
       serverUrl
@@ -286,7 +286,7 @@ function ExpressionTable() {
       .catch(error => console.error('Request failed:', error));
       // The following code assumes the HTMLHistory[] returend by Herbie
       // is mapped to the alternatives array 1:1
-      const d = histories[i];
+      const d = histories?.[i];
       const newDerivation = new Derivation(d, newId, expression.id, derivationsObjects[i]);
       newDerivations.push(newDerivation);
     }

--- a/src/herbie/HerbieTypes.ts
+++ b/src/herbie/HerbieTypes.ts
@@ -15,8 +15,9 @@ export type ProofStep = {
 };
 
 type CommonFields = {
-  error: number | "N/A";
+  error?: number | "N/A";
   "training-error"?: number | "N/A";
+  program: string;
   prev?: DerivationNode;
 };
 
@@ -29,13 +30,11 @@ type StartNode = CommonFields & {
 
 type AddPreprocessingNode = CommonFields & {
   type: "add-preprocessing";
-  program: string;
   preprocessing: any[];
 };
 
 type TaylorNode = CommonFields & {
   type: "taylor";
-  program: string;
   loc: number[];
   pt: string;
   var: string;
@@ -45,20 +44,33 @@ type RRNode = CommonFields & {
   error: number;
   "training-error": number;
   type: "rr";
-  program: string;
   loc: number[];
   proof: ProofStep[];
 };
 
-export type DerivationNode = StartNode | AddPreprocessingNode | TaylorNode | RRNode;
+type RegimesNode = CommonFields & {
+  type: "regimes";
+  conditions: string[][];
+  prevs: DerivationNode[];
+};
+
+type FinalSimplifyNode = CommonFields & {
+  type: "final-simplify";
+  error: number;
+  "training-error": number;
+  prev: DerivationNode;
+  // TODO
+};
+
+export type DerivationNode = StartNode | AddPreprocessingNode | TaylorNode | RRNode | RegimesNode | FinalSimplifyNode;
 
 export class Derivation {
   /**
-   * @param history: The HTMLHistory object containing the derivation (as HTML) for an alternative expression
+   * @param history: (deprecated) The HTMLHistory object containing the derivation (as HTML) for an alternative expression
    * @param id: The id of this derivation, the same id as the expression this derivation is for
    * @param origExpId: The id of the expression that was improved resulting in the alternative this derivation is for
    */
-  constructor(public readonly history: HTMLHistory, public readonly id: number, public readonly origExpId: number | undefined, public readonly derivation?: DerivationNode) {
+  constructor(public readonly history: HTMLHistory | undefined, public readonly id: number, public readonly origExpId: number | undefined, public readonly derivation?: DerivationNode) {
     this.history = history;
     this.id = id;
     this.origExpId = origExpId;    

--- a/src/herbie/lib/herbiejs.ts
+++ b/src/herbie/lib/herbiejs.ts
@@ -135,8 +135,8 @@ interface HerbieAlternativesResponse {
   alternatives: FPCore[];
 
   /** The history of each alternative. (e.g. alternatives[1] will have its history stored in
- * histories[1] and splitpoints in splitpoints[1]) */
-  histories: HTMLHistory[];
+ * histories[1] (deprecated, use derivations instead) and splitpoints in splitpoints[1]) */
+  histories?: HTMLHistory[];
 
   /** The splitpoints for each alternative. (e.g. alternatives[1] will have its history stored in
  * histories[1] and splitpoints in splitpoints[1]) */
@@ -179,7 +179,7 @@ export interface ExpressionExportResponse {
   result: string;
 }
 
-export const analyzeExpressionExport = async (
+export const translateFpcoreToLanguage = async (
   fpcore: string,
   language: string,
   host: string


### PR DESCRIPTION
This PR deprecates the "histories" field in the /alternatives endpoint response and switches to rendering from a JSON representation of the derivations.

It includes type definitions for derivation and proof nodes in HerbieTypes.ts.

Because each derivation node must be rendered as LaTeX, it should be noted that this significantly increases the number of server calls. Possibly, to avoid this, the server could pre-render the returned FPCore expressions.